### PR TITLE
fix metrics density comparisons

### DIFF
--- a/core/java/android/view/DisplayInfo.java
+++ b/core/java/android/view/DisplayInfo.java
@@ -447,6 +447,8 @@ public final class DisplayInfo implements Parcelable {
         } else if (type == Display.TYPE_BUILT_IN
                 && (flags & Display.FLAG_PRESENTATION) == 0) {
             outMetrics.setDensity(DisplayMetrics.DENSITY_PREFERRED);
+        } else {
+            outMetrics.setDensity(logicalDensityDpi);
         }
     }
 


### PR DESCRIPTION
In Resources.java, we explicitly call setDensity() on the local
DisplayMetircs object when there is a configuration update - which
sets some more fields than the original implementation.

In fw/b/core/java/android/app/Presentation.java there is a DisplayInfo
comparison which fails because our getMetricsWithSize() did not always
set those fields that updateConfiguration would always set.

So now we always return a DisplayMetrics object with the fields filled
out as expected.

Ref: OPO-539

Change-Id: Ie80e7a9cfd249ec59d31b4044ad09e07e34d1194
Signed-off-by: Roman Birg <roman@cyngn.com>
(cherry picked from commit ea229d417f4ef641564c535246c41cdf96284ffd)
(cherry picked from commit 28ea15c1ddb4d37607be23b2f7c4d88b89497f15)