### PR TITLE
SystemUI: remove deleted broadcast receiver

### DIFF
--- a/packages/SystemUI/AndroidManifest.xml
+++ b/packages/SystemUI/AndroidManifest.xml
@@ -186,13 +186,6 @@
             </intent-filter>
         </receiver>
 
-        <receiver android:name=".qs.tiles.HotspotTile$APChangedReceiver"
-                androidprv:primaryUserOnly="true">
-            <intent-filter>
-                <action android:name="android.net.wifi.WIFI_AP_STATE_CHANGED" />
-            </intent-filter>
-        </receiver>
-
         <activity android:name=".usb.UsbStorageActivity"
                   android:label="@*android:string/usb_storage_activity_title"
                   android:excludeFromRecents="true">


### PR DESCRIPTION
Commit 221a7eefdc435ac4f32f3a1b5347940eb803fb0d removed said broadcast
receiver

Change-Id: I72405174b8f9025babd29b584d2a6fec3a667166
Signed-off-by: Roman Birg <roman@cyngn.com>