### PR TITLE
Fix ownership for files/folders created by ExternalStorageProvider on…

### DIFF
--- a/packages/ExternalStorageProvider/src/com/android/externalstorage/ExternalStorageProvider.java
+++ b/packages/ExternalStorageProvider/src/com/android/externalstorage/ExternalStorageProvider.java
@@ -169,6 +169,14 @@ public class ExternalStorageProvider extends DocumentsProvider {
                     root.visiblePath = null;
                 }
                 root.path = volume.getInternalPathForUser(userId);
+
+                // Force all ext4/f2fs sdcard acccess through the sdcard FUSE layer to ensure the
+                // correct permissions for accessing files and directories.
+                if (volume.getType() == VolumeInfo.TYPE_PUBLIC && root.visiblePath != null
+                    && ("ext4".equals(volume.fsType) || "f2fs".equals(volume.fsType))) {
+                    root.path = root.visiblePath;
+                }
+
                 root.docId = getDocIdForFile(root.path);
 
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
… ext4/f2fs

By forcing ExternalStorageProvider to use the sdcard FUSE layer for access,
ext4/f2fs sdcards will be treated with the correct media_rw:media_rw
permissions instead of the current app permissions.

Change-Id: I2cbb97727ebe5af88a879490732925406a165af5